### PR TITLE
Fix typo in EnvironmentConfig

### DIFF
--- a/src/configs/app_config.py
+++ b/src/configs/app_config.py
@@ -7,7 +7,7 @@ from pydantic_settings import (
 )
 
 from .deploy import DeploymentConfig
-from .enviornment import EnviornmentConfig
+from .enviornment import EnvironmentConfig
 from .packaging import PackagingConfig
 
 logger = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class MadcrowConfig(
     DeploymentConfig,
-    EnviornmentConfig,
+    EnvironmentConfig,
     # Packaging info
     PackagingConfig,
 ):

--- a/src/configs/enviornment/__init__.py
+++ b/src/configs/enviornment/__init__.py
@@ -5,7 +5,7 @@ from .redis_config import RedisConfig
 from .security_config import SecurityConfig
 
 
-class EnviornmentConfig(
+class EnvironmentConfig(
     # place the configs in alphabet order
     HttpConfig,
     LoggingConfig,


### PR DESCRIPTION
## What this PR does?

This PR is fix typo in class EnvironmentConfig name.

Closes: https://github.com/sayonetech/fastapi-boilerplate/issues/2